### PR TITLE
Fix: TOsslLoader does not update loading status after unloading.

### DIFF
--- a/Source/Ossl4Pas.Loader.pas
+++ b/Source/Ossl4Pas.Loader.pas
@@ -1191,7 +1191,7 @@ begin
   end
   else if not CheckLibVersion(Result, ALibVer) then
   begin
-    Result.LibFree;
+    FreeLibrary(Result);
 
     RaiseExceptionResFmt(@resNoVersionFound, [ALibName]);
   end;
@@ -1418,7 +1418,7 @@ begin
 
   except
     if not Result.IsEmpty then
-      Result.LibFree;
+      FreeLibrary(Result);
     raise
   end;
 end;
@@ -1474,7 +1474,11 @@ begin
   DoUnBind(ALibTypes);
   for lLibType:=High(TLibType) downto Low(TLibType) do
     if InstIsLibLoaded[lLibType] then
-      InstLibHandle[lLibType].LibFree;
+    try
+      FreeLibrary(InstLibHandle[lLibType]);
+    finally
+      InstLibHandle[lLibType]:=TLibHandle.cNilHandle;
+    end;
 end;
 
 {$ENDREGION 'TOsslLoader Instance methods'}

--- a/Source/Ossl4Pas.Types.pas
+++ b/Source/Ossl4Pas.Types.pas
@@ -228,9 +228,6 @@ type
     /// <summary>Retrieves the address of an exported function.</summary>
     property ProcAddress[const AProcName: string]: pointer read DoGetProcAddress;
 
-    /// <summary>Unloads the library and releases handle.</summary>
-    procedure LibFree; {$IFDEF INLINE_ON}inline;{$ENDIF}
-
     /// <summary>Retrieves the file name of the loaded module.</summary>
     property FileName: string read DoGetFileName;
   end;
@@ -416,16 +413,6 @@ begin
   if Self = 0 then
     Exit;
   Result:=GetProcAddress(Self, PChar(AProcName));
-end;
-
-procedure TLibHandleHelper.LibFree;
-begin
-  if not Self.IsEmpty then
-  try
-    FreeLibrary(Self);
-  finally
-    Self:=cNilHandle;
-  end;
 end;
 
 function TLibHandleHelper.DoGetFileName: string;


### PR DESCRIPTION
Fixes #39
`procedure TLibHandleHelper.LibFree;` removed to avoid unloading using copy of the handler.
The procedure `TOsslLoader.InternalUnload` unloads and update the library handle correctly in the Loader singleton instance.