### PR TITLE
Fix: Bug #63

### DIFF
--- a/Tests/Mocks/mockLibs/Ossl4Pas.UT.Mock.Version.pas
+++ b/Tests/Mocks/mockLibs/Ossl4Pas.UT.Mock.Version.pas
@@ -98,20 +98,28 @@ end;
 function IsLibName(var ALibName: PChar): boolean; cdecl;
 var
   lDirName, lFileName: string;
+  lLibName: string;
 
 begin
-  lDirName:=TPath.GetDirectoryName(ALibName);
-  lFileName:=TPath.GetFileName(ALibName);
-{$IFDEF MSWINDOWS}
-  Result:=SameText(TPath.GetFileName(GLibPath), lFileName);
-  if not lDirName.IsEmpty then
-    Result:=Result and SameText(TPath.GetDirectoryName(GLibPath), lDirName);
-{$ELSE}
-  Result:=SameStr(TPath.GetFileName(GLibPath), lFileName);
-  if not lDirName.IsEmpty then
-    Result:=Result and SameStr(TPath.GetDirectoryName(GLibPath), lDirName);
-{$ENDIF}
-  ALibName:=Pchar(GLibPath);
+  try
+    lLibName:=string(ALibName);
+    lDirName:=TPath.GetDirectoryName(lLibName);
+    lFileName:=TPath.GetFileName(lLibName);
+    {$IFDEF MSWINDOWS}
+    Result:=SameText(TPath.GetFileName(GLibPath), lFileName);
+    if not lDirName.IsEmpty then
+      Result:=Result and SameText(TPath.GetDirectoryName(GLibPath), lDirName);
+    {$ELSE}
+    Result:=SameStr(TPath.GetFileName(GLibPath), lFileName);
+    if not lDirName.IsEmpty then
+      Result:=Result and SameStr(TPath.GetDirectoryName(GLibPath), lDirName);
+    {$ENDIF}
+    ALibName:=PChar(GLibPath);
+
+  except
+    Result:=False;
+    ALibName:=nil;
+  end;
 end;
 
 procedure CheckLibPath;

--- a/Tests/TOsslLoader/Ossl4Pas.UT.Binding.Behavior.pas
+++ b/Tests/TOsslLoader/Ossl4Pas.UT.Binding.Behavior.pas
@@ -65,7 +65,6 @@ type
     procedure BindIsLibName(ALibType: TLibType; AVersion: culong;
       AExpected: TBindKind);
 
-//    [Category('Debug')]
     [AutoNameTestCase('ltCrypto,$3000000F,bkFallBack')]
     [AutoNameTestCase('ltCrypto,$3020000F,bkFallBack')]
     [AutoNameTestCase('ltCrypto,$3060000F,bkFallBack')]
@@ -358,7 +357,7 @@ end;
 
 procedure CheckIsLib;
 begin
-  var lPLibName: PChar;
+  var lPLibName: PChar:='';
   Assert.IsFalse(TTestApiClass.IsLibName(lPLibName), 'IsLibName should returned False');
 end;
 
@@ -371,10 +370,6 @@ begin
   case AExpected of
     bkNone:
       CheckIsLib;
-//    begin
-//      var lPLibName: PChar;
-//      Assert.IsFalse(TTestApiClass.IsLibName(lPLibName), 'IsLibName should returned False');
-//    end;
     bkStub:
       Assert.WillRaise(
         procedure begin CheckIsLib; end,


### PR DESCRIPTION
Uninitialized PChar pointer has passed to the mock library function call that has lead an exception
in the library code.
Delphi can't capture exception generated by generic procedure in the library if it called through procedural variable.

Fixes:
- Initialized variable is passed to the IsLibName moklib function.
- Added try..except block in IsLibName moklib function to avoid unpredictable test behavior