### PR TITLE
Fix unit tests for D10.4.2

### DIFF
--- a/Tests/Mocks/mockLibs/Ossl4Pas.UT.Mock.Version.pas
+++ b/Tests/Mocks/mockLibs/Ossl4Pas.UT.Mock.Version.pas
@@ -48,6 +48,25 @@ implementation
 const
   cDefaultVersion: culong = $3000000F;
 
+{$IF not Defined(VER3600) }
+type
+  TFIleHelper = record helper for TFile
+    class function GetSize(AFileName: string): Int64; static;
+  end;
+
+class function TFIleHelper.GetSize(AFileName: string): Int64;
+begin
+  var lStream: TFileStream:=nil;
+  try
+    lStream:=TFileStream.Create(AFileName, fmOpenRead);
+    Result:=lStream.Size;
+  finally
+    lStream.Free;
+  end;
+end;
+{$ENDIF}
+
+
 function LoadVersion: culong;
 var
   lPath: string;
@@ -133,6 +152,8 @@ begin
   if not lPath.IsEmpty then
     GLibPath:=lPath;
 end;
+
+{ TFIleHelper }
 
 initialization
   CheckLibPath;

--- a/Tests/TOsslLoader/Ossl4Pas.UT.Binding.Behavior.pas
+++ b/Tests/TOsslLoader/Ossl4Pas.UT.Binding.Behavior.pas
@@ -182,12 +182,12 @@ begin
   TOsslBinding.Reset(cBindingNull, False);
 end;
 
-class procedure TTestApiClass.RaiseNullBind(AMethodName: string); noreturn;
+class procedure TTestApiClass.RaiseNullBind(AMethodName: string);
 begin
   raise ENullBind.Create(AMethodName);
 end;
 
-class procedure TTestApiClass.RaiseFallBackBind(AMethodName: string); noreturn;
+class procedure TTestApiClass.RaiseFallBackBind(AMethodName: string);
 begin
   raise EFallBack.Create(AMethodName);
 end;
@@ -198,7 +198,7 @@ begin
   Result:=0;
 end;
 
-class function TTestApiClass.FallBackDummyStr: PChar; noreturn;
+class function TTestApiClass.FallBackDummyStr: PChar;
 begin
   RaiseFallBackBind(cDummyStrName);
   Result:=nil;

--- a/Tests/TOsslLoader/Ossl4Pas.UT.Loader.Behavior.pas
+++ b/Tests/TOsslLoader/Ossl4Pas.UT.Loader.Behavior.pas
@@ -304,12 +304,14 @@ begin
 end;
 
 procedure TOsslCustomLoaderBehaviorFixture.MultiThreadLoading(ACount: integer);
+var
+  lThreads: array of TThread;
+
 begin
   Assert.IsTrue(ACount > 0, '''ACount must be greater than zero.');
 
   var lStartSignal: TSimpleEvent:=nil;
   var lCompleteSignal: TCountdownEvent:=nil;
-  var lThreads: array of TThread;
 
   try
     lStartSignal:=TSimpleEvent.Create(nil, True, False, '');


### PR DESCRIPTION
Unit tests and mocks compilation failed with
Delphi 10.4.2.
Fixes:
- TFile helper added to mocklib project to support TFile.GetSize method.
- D10.4 does not support array local variable. Such variable(s) moved to `var` section
- `noreturn` modifier removed